### PR TITLE
Construct bases-mask from samplesheet

### DIFF
--- a/bcl2fastq/bcl2fastq/lib/bcl2fastq_utils.py
+++ b/bcl2fastq/bcl2fastq/lib/bcl2fastq_utils.py
@@ -77,7 +77,7 @@ class Bcl2FastqConfig:
         :return a dict of the lane and base mask to use, e.g.:
                  { 1:"y*,iiiiiiii,iiiiiiii,y*" , 2:"y*,iiiiii,n*,y*  [etc] }
         """
-        def isDoubleIndex(idx):
+        def is_double_index(idx):
             return "-" in idx
 
         def construct_double_index_basemask(idx):
@@ -94,11 +94,11 @@ class Bcl2FastqConfig:
         lanes_and_indexes = samplesheet_df.loc[:,["Lane","Index"]]
         first_index_and_lane = lanes_and_indexes.groupby(lanes_and_indexes.Lane).first()
         indexes = first_index_and_lane["Index"].to_dict()
-        contains_double_index = True in map(isDoubleIndex, indexes.values())
+        contains_double_index = True in map(is_double_index, indexes.values())
 
         base_masks = {}
         for lane, read_index in indexes.iteritems():
-            if isDoubleIndex(read_index):
+            if is_double_index(read_index):
                 base_masks[lane] = construct_double_index_basemask(read_index.strip())
             else:
                 base_masks[lane] = construct_single_index_basemask(read_index.strip(), contains_double_index)

--- a/bcl2fastq/bcl2fastq/lib/bcl2fastq_utils.py
+++ b/bcl2fastq/bcl2fastq/lib/bcl2fastq_utils.py
@@ -39,6 +39,9 @@ class Bcl2FastqConfig:
 
         self.barcode_mismatches = barcode_mismatches
         self.tiles = tiles
+        # TODO Ensure that this is included in any user facing documentation.
+        # Note that for the base mask the "--use_base_mask" must be included in the
+        # commandline passed. E.g. "--use_base_mask 1:y*,6i,6i, y* --use_base_mask y*,6i,6i, y* "
         self.use_base_mask = use_base_mask
         self.additional_args = additional_args
 
@@ -250,7 +253,9 @@ class BCL2Fastq2xRunner(BCL2FastqRunner):
             commandline_collection.append("--tiles " + self.config.tiles)
 
         if self.config.use_base_mask:
-            commandline_collection.append("--use_base_mask " + self.config.use_base_mask)
+            # Note that for the base mask the "--use_base_mask" must be included in the
+            # commandline passed.
+            commandline_collection.append(self.config.use_base_mask)
         else:
             lanes_and_base_mask = Bcl2FastqConfig.get_bases_mask_per_lane_from_samplesheet(self.config.samplesheet)
             for lane, base_mask in lanes_and_base_mask.iteritems():

--- a/bcl2fastq/bcl2fastq/lib/bcl2fastq_utils.py
+++ b/bcl2fastq/bcl2fastq/lib/bcl2fastq_utils.py
@@ -68,6 +68,19 @@ class Bcl2FastqConfig:
         return version
 
     @staticmethod
+    def get_length_of_indexes(runfolder):
+        """
+        Will parse runfolder meta data to find the length of the index reads.
+        :param runfolder: to get the length of the index reads from.
+        :return: a cict with the index number as key and the length of each index as value e.g.:
+                 {1: 7, 2: 8}
+        """
+        meta_data = InteropMetadata(runfolder)
+        index_read_info = filter(lambda x: x["is_index"], meta_data.read_config)
+        indexes_and_lengths = map(lambda x: (x["read_num"], x["cycles"]), index_read_info)
+        return dict(indexes_and_lengths)
+
+    @staticmethod
     def get_bases_mask_per_lane_from_samplesheet(samplesheet_file):
         """
         Create a bases-mask string per lane for based on the length of the index in the

--- a/bcl2fastq/requirements.txt
+++ b/bcl2fastq/requirements.txt
@@ -5,3 +5,5 @@ git+https://github.com/johandahlberg/localq.git@with_shell_true # Get from pip i
 mock # only for tests
 pyyaml
 illuminate
+pandas
+

--- a/bcl2fastq/tests/sampledata/samplesheet_example.csv
+++ b/bcl2fastq/tests/sampledata/samplesheet_example.csv
@@ -1,0 +1,56 @@
+FCID,Lane,SampleID,SampleRef,Index,Description,Control,Recipe,Operator,SampleProject
+C6KV6ANXX,1,Sample_1,1,ATTACTCG-TATAGCCT,Library_1,,,,Dummy_Project
+C6KV6ANXX,1,Sample_2,1,ATTACTCG-ATAGAGGC,Library_2,,,,Dummy_Project
+C6KV6ANXX,1,Sample_3,1,ATTACTCG-CCTATCCT,Library_3,,,,Dummy_Project
+C6KV6ANXX,1,Sample_4,1,ATTACTCG-GGCTCTGA,Library_4,,,,Dummy_Project
+C6KV6ANXX,1,Sample_5,1,ATTACTCG-AGGCGAAG,Library_5,,,,Dummy_Project
+C6KV6ANXX,1,Sample_6,1,ATTACTCG-TAATCTTA,Library_6,,,,Dummy_Project
+C6KV6ANXX,1,Sample_7,1,ATTACTCG-CAGGACGT,Library_7,,,,Dummy_Project
+C6KV6ANXX,1,Sample_8,1,ATTACTCG-GTACTGAC,Library_8,,,,Dummy_Project
+C6KV6ANXX,1,Sample_9,1,TCCGGAGA-TATAGCCT,Library_9,,,,Dummy_Project
+C6KV6ANXX,1,Sample_10,1,TCCGGAGA-ATAGAGGC,Library_10,,,,Dummy_Project
+C6KV6ANXX,1,Sample_11,1,TCCGGAGA-CCTATCCT,Library_11,,,,Dummy_Project
+C6KV6ANXX,1,Sample_12,1,TCCGGAGA-GGCTCTGA,Library_12,,,,Dummy_Project
+C6KV6ANXX,1,Sample_13,1,TCCGGAGA-AGGCGAAG,Library_13,,,,Dummy_Project
+C6KV6ANXX,1,Sample_14,1,TCCGGAGA-CAGGACGT,Library_14,,,,Dummy_Project
+C6KV6ANXX,1,Sample_15,1,TCCGGAGA-GTACTGAC,Library_15,,,,Dummy_Project
+C6KV6ANXX,1,Sample_16,1,CGCTCATT-TATAGCCT,Library_16,,,,Dummy_Project
+C6KV6ANXX,1,Sample_17,1,CGCTCATT-ATAGAGGC,Library_17,,,,Dummy_Project
+C6KV6ANXX,1,Sample_18,1,CGCTCATT-CCTATCCT,Library_18,,,,Dummy_Project
+C6KV6ANXX,1,Sample_19,1,CGCTCATT-GGCTCTGA,Library_19,,,,Dummy_Project
+C6KV6ANXX,1,Sample_20,1,GAGATTCC-TATAGCCT,Library_20,,,,Dummy_Project
+C6KV6ANXX,1,Sample_21,1,GAGATTCC-ATAGAGGC,Library_21,,,,Dummy_Project
+C6KV6ANXX,1,Sample_22,1,GAGATTCC-CCTATCCT,Library_22,,,,Dummy_Project
+C6KV6ANXX,1,Sample_23,1,GAGATTCC-GGCTCTGA,Library_23,,,,Dummy_Project
+C6KV6ANXX,2,Sample_24,1,CGATGT,Library_24,,,,Dummy_Project
+C6KV6ANXX,2,Sample_25,1,TGACCA,Library_25,,,,Dummy_Project
+C6KV6ANXX,2,Sample_26,1,ACAGTG,Library_26,,,,Dummy_Project
+C6KV6ANXX,2,Sample_27,1,GCCAAT,Library_27,,,,Dummy_Project
+C6KV6ANXX,2,Sample_28,1,ATGTCA,Library_28,,,,Dummy_Project
+C6KV6ANXX,2,Sample_29,1,CCGTCC,Library_29,,,,Dummy_Project
+C6KV6ANXX,2,Sample_30,1,GTCCGC,Library_30,,,,Dummy_Project
+C6KV6ANXX,2,Sample_31,1,GTGAAA,Library_31,,,,Dummy_Project
+C6KV6ANXX,3,Sample_32,1,CGATGT,Library_32,,,,Dummy_Project
+C6KV6ANXX,3,Sample_33,1,TGACCA,Library_33,,,,Dummy_Project
+C6KV6ANXX,3,Sample_34,1,ACAGTG,Library_34,,,,Dummy_Project
+C6KV6ANXX,3,Sample_35,1,GCCAAT,Library_35,,,,Dummy_Project
+C6KV6ANXX,3,Sample_36,1,CAGATC,Library_36,,,,Dummy_Project
+C6KV6ANXX,3,Sample_37,1,CTTGTA,Library_37,,,,Dummy_Project
+C6KV6ANXX,3,Sample_38,1,AGTCAA,Library_38,,,,Dummy_Project
+C6KV6ANXX,3,Sample_39,1,AGTTCC,Library_39,,,,Dummy_Project
+C6KV6ANXX,4,Sample_40,1,CTCGATG,Library_40,,,,Dummy_Project
+C6KV6ANXX,4,Sample_41,1,TGCGTCC ,Library_41,,,,Dummy_Project
+C6KV6ANXX,4,Sample_42,1,ACTATCA ,Library_42,,,,Dummy_Project
+C6KV6ANXX,4,Sample_43,1,GGCGGAG ,Library_43,,,,Dummy_Project
+C6KV6ANXX,5,Sample_44,1,CTCGATG,Library_44,,,,Dummy_Project
+C6KV6ANXX,5,Sample_45,1,TGCGTCC ,Library_45,,,,Dummy_Project
+C6KV6ANXX,5,Sample_46,1,ACTATCA ,Library_46,,,,Dummy_Project
+C6KV6ANXX,5,Sample_47,1,GGCGGAG ,Library_47,,,,Dummy_Project
+C6KV6ANXX,6,Sample_48,1,CAGGAAG ,Library_48,,,,Dummy_Project
+C6KV6ANXX,6,Sample_49,1,TAATGCG ,Library_49,,,,Dummy_Project
+C6KV6ANXX,6,Sample_50,1,ACCAACG,Library_50,,,,Dummy_Project
+C6KV6ANXX,7,Sample_51,1,CAGGAAG ,Library_51,,,,Dummy_Project
+C6KV6ANXX,7,Sample_52,1,TAATGCG ,Library_52,,,,Dummy_Project
+C6KV6ANXX,7,Sample_53,1,ACCAACG,Library_53,,,,Dummy_Project
+C6KV6ANXX,8,Sample_54,1,CATGCTC ,Library_54,,,,Dummy_Project
+C6KV6ANXX,8,Sample_55,1,TCGCAGG ,Library_55,,,,Dummy_Project

--- a/bcl2fastq/tests/test_bcl2fastq_handlers.py
+++ b/bcl2fastq/tests/test_bcl2fastq_handlers.py
@@ -12,14 +12,14 @@ from bcl2fastq.app import create_app
 class TestBcl2FastqHandlers(AsyncHTTPTestCase):
 
     API_BASE="/api/1.0"
-    MOCK_BCL2FASTQ_DICT =  {1: "y*,iiiiiiii,iiiiiiii,y*",
-                            2: "y*,iiiiii,n*,y*",
-                            3: "y*,iiiiii,n*,y*",
-                            4: "y*,iiiiiii,n*,y*",
-                            5: "y*,iiiiiii,n*,y*",
-                            6: "y*,iiiiiii,n*,y*",
-                            7: "y*,iiiiiii,n*,y*",
-                            8: "y*,iiiiiii,n*,y*",
+    MOCK_BCL2FASTQ_DICT =  {1: "y*,8i,8i,y*",
+                            2: "y*,6i,n*,y*",
+                            3: "y*,6i,n*,y*",
+                            4: "y*,7i,n*,y*",
+                            5: "y*,7i,n*,y*",
+                            6: "y*,7i,n*,y*",
+                            7: "y*,7i,n*,y*",
+                            8: "y*,7i,n*,y*",
                             }
 
     def get_app(self):

--- a/bcl2fastq/tests/tests_bcl2fastq.py
+++ b/bcl2fastq/tests/tests_bcl2fastq.py
@@ -21,7 +21,7 @@ class TestBcl2FastqConfig(unittest.TestCase):
     def test_get_bases_mask_per_lane_from_samplesheet(self):
         #TODO Fix test to match that we might now have a read that uses the full
         # lenght of the read.
-        mock_read_index_lengths = {1: 9, 2: 9}
+        mock_read_index_lengths = {2: 9, 3: 9}
         expected_bases_mask = {1: "y*,8in*,8in*,y*",
                                2: "y*,6in*,n*,y*",
                                3: "y*,6in*,n*,y*",
@@ -37,7 +37,7 @@ class TestBcl2FastqConfig(unittest.TestCase):
 
     def test_get_bases_mask_per_lane_from_samplesheet_invalid_length_combo(self):
         # These are to short compared to the length indicated in the samplesheet
-        mock_read_index_lengths = {1: 4, 2: 4}
+        mock_read_index_lengths = {2: 4, 3: 4}
 
         with self.assertRaises(AssertionError):
             Bcl2FastqConfig.\
@@ -83,7 +83,7 @@ class TestBCL2Fastq2xRunner(unittest.TestCase):
             output = "test/output",
             barcode_mismatches = "2",
             tiles="s1,s2,s3",
-            use_base_mask="--use_base_mask y*,6i,6i,y* --use_base_mask 1:y*,5i,5i,y*",
+            use_base_mask="--use-bases-mask y*,6i,6i,y* --use-bases-mask 1:y*,5i,5i,y*",
             additional_args="--my-best-arg 1 --my-best-arg 2")
 
         runner = BCL2Fastq2xRunner(config, "/bcl/binary/path")
@@ -91,7 +91,7 @@ class TestBCL2Fastq2xRunner(unittest.TestCase):
         expected_command = "/bcl/binary/path --input-dir test/runfolder/Data/Intensities/BaseCalls " \
                            "--output-dir test/output --barcode-mismatches 2 " \
                            "--tiles s1,s2,s3 " \
-                           "--use_base_mask y*,6i,6i,y* --use_base_mask 1:y*,5i,5i,y* " \
+                           "--use-bases-mask y*,6i,6i,y* --use-bases-mask 1:y*,5i,5i,y* " \
                            "--my-best-arg 1 --my-best-arg 2"
         self.assertEqual(command, expected_command)
 

--- a/bcl2fastq/tests/tests_bcl2fastq.py
+++ b/bcl2fastq/tests/tests_bcl2fastq.py
@@ -6,6 +6,7 @@ from test_utils import TestUtils
 class TestBcl2FastqConfig(unittest.TestCase):
 
     test_dir = os.path.dirname(os.path.realpath(__file__))
+    samplesheet_file = test_dir + "/sampledata/samplesheet_example.csv"
 
     def test_get_bcl2fastq_version_from_run_parameters(self):
         runfolder = TestBcl2FastqConfig.test_dir + "/sampledata/HiSeq-samples/2014-02_13_average_run"
@@ -20,18 +21,27 @@ class TestBcl2FastqConfig(unittest.TestCase):
     def test_get_bases_mask_per_lane_from_samplesheet(self):
         #TODO Fix test to match that we might now have a read that uses the full
         # lenght of the read.
-        samplesheet_file = TestBcl2FastqConfig.test_dir + "/sampledata/samplesheet_example.csv"
-        expected_bases_mask = {1: "y*,iiiiiiii,iiiiiiii,y*",
-                               2: "y*,iiiiii,n*,y*",
-                               3: "y*,iiiiii,n*,y*",
-                               4: "y*,iiiiiii,n*,y*",
-                               5: "y*,iiiiiii,n*,y*",
-                               6: "y*,iiiiiii,n*,y*",
-                               7: "y*,iiiiiii,n*,y*",
-                               8: "y*,iiiiiii,n*,y*",
+        mock_read_index_lengths = {1: 9, 2: 9}
+        expected_bases_mask = {1: "y*,8in*,8in*,y*",
+                               2: "y*,6in*,n*,y*",
+                               3: "y*,6in*,n*,y*",
+                               4: "y*,7in*,n*,y*",
+                               5: "y*,7in*,n*,y*",
+                               6: "y*,7in*,n*,y*",
+                               7: "y*,7in*,n*,y*",
+                               8: "y*,7in*,n*,y*",
                                }
-        actual_bases_mask = Bcl2FastqConfig.get_bases_mask_per_lane_from_samplesheet(samplesheet_file)
+        actual_bases_mask = Bcl2FastqConfig.\
+            get_bases_mask_per_lane_from_samplesheet(TestBcl2FastqConfig.samplesheet_file, mock_read_index_lengths)
         self.assertEqual(expected_bases_mask, actual_bases_mask)
+
+    def test_get_bases_mask_per_lane_from_samplesheet_invalid_length_combo(self):
+        # These are to short compared to the length indicated in the samplesheet
+        mock_read_index_lengths = {1: 4, 2: 4}
+
+        with self.assertRaises(AssertionError):
+            Bcl2FastqConfig.\
+                get_bases_mask_per_lane_from_samplesheet(TestBcl2FastqConfig.samplesheet_file, mock_read_index_lengths)
 
 
 class TestBCL2FastqRunnerFactory(unittest.TestCase):

--- a/bcl2fastq/tests/tests_bcl2fastq.py
+++ b/bcl2fastq/tests/tests_bcl2fastq.py
@@ -5,11 +5,27 @@ from test_utils import TestUtils
 
 class TestBcl2FastqConfig(unittest.TestCase):
 
+    test_dir = os.path.dirname(os.path.realpath(__file__))
+
     def test_get_bcl2fastq_version_from_run_parameters(self):
-        test_dir = os.path.dirname(os.path.realpath(__file__))
-        runfolder = test_dir + "/sampledata/HiSeq-samples/2014-02_13_average_run"
+        runfolder = TestBcl2FastqConfig.test_dir + "/sampledata/HiSeq-samples/2014-02_13_average_run"
         version = Bcl2FastqConfig.get_bcl2fastq_version_from_run_parameters(runfolder, TestUtils.DUMMY_CONFIG)
         self.assertEqual(version, "1.8.4")
+
+    def test_get_bases_mask_per_lane_from_samplesheet(self):
+        samplesheet_file = TestBcl2FastqConfig.test_dir + "/sampledata/samplesheet_example.csv"
+        expected_bases_mask = {1: "y*,iiiiiiii,iiiiiiii,y*",
+                               2: "y*,iiiiii,n*,y*",
+                               3: "y*,iiiiii,n*,y*",
+                               4: "y*,iiiiiii,n*,y*",
+                               5: "y*,iiiiiii,n*,y*",
+                               6: "y*,iiiiiii,n*,y*",
+                               7: "y*,iiiiiii,n*,y*",
+                               8: "y*,iiiiiii,n*,y*",
+                               }
+        actual_bases_mask = Bcl2FastqConfig.get_bases_mask_per_lane_from_samplesheet(samplesheet_file)
+        self.assertEqual(expected_bases_mask, actual_bases_mask)
+
 
 class TestBCL2FastqRunnerFactory(unittest.TestCase):
 

--- a/bcl2fastq/tests/tests_bcl2fastq.py
+++ b/bcl2fastq/tests/tests_bcl2fastq.py
@@ -12,7 +12,14 @@ class TestBcl2FastqConfig(unittest.TestCase):
         version = Bcl2FastqConfig.get_bcl2fastq_version_from_run_parameters(runfolder, TestUtils.DUMMY_CONFIG)
         self.assertEqual(version, "1.8.4")
 
+    def test_get_length_of_indexes(self):
+        runfolder = TestBcl2FastqConfig.test_dir + "/sampledata/HiSeq-samples/2014-02_13_average_run"
+        index_and_length = Bcl2FastqConfig.get_length_of_indexes(runfolder)
+        self.assertEqual(index_and_length, {2: 7})
+
     def test_get_bases_mask_per_lane_from_samplesheet(self):
+        #TODO Fix test to match that we might now have a read that uses the full
+        # lenght of the read.
         samplesheet_file = TestBcl2FastqConfig.test_dir + "/sampledata/samplesheet_example.csv"
         expected_bases_mask = {1: "y*,iiiiiiii,iiiiiiii,y*",
                                2: "y*,iiiiii,n*,y*",

--- a/bcl2fastq/tests/tests_bcl2fastq.py
+++ b/bcl2fastq/tests/tests_bcl2fastq.py
@@ -83,14 +83,15 @@ class TestBCL2Fastq2xRunner(unittest.TestCase):
             output = "test/output",
             barcode_mismatches = "2",
             tiles="s1,s2,s3",
-            use_base_mask="Y*NN",
+            use_base_mask="--use_base_mask y*,6i,6i,y* --use_base_mask 1:y*,5i,5i,y*",
             additional_args="--my-best-arg 1 --my-best-arg 2")
 
         runner = BCL2Fastq2xRunner(config, "/bcl/binary/path")
         command = runner.construct_command()
         expected_command = "/bcl/binary/path --input-dir test/runfolder/Data/Intensities/BaseCalls " \
                            "--output-dir test/output --barcode-mismatches 2 " \
-                           "--tiles s1,s2,s3 --use_base_mask Y*NN " \
+                           "--tiles s1,s2,s3 " \
+                           "--use_base_mask y*,6i,6i,y* --use_base_mask 1:y*,5i,5i,y* " \
                            "--my-best-arg 1 --my-best-arg 2"
         self.assertEqual(command, expected_command)
 


### PR DESCRIPTION
The bases-mask will per default be defined based on the index defined in the samplesheet, on a per lane basis.

Currently this only supports the old style of illumina samplesheets, but we need to make sure it supports the new style as well.