### PR TITLE
New log directory

### DIFF
--- a/runfolder/config/logger.config
+++ b/runfolder/config/logger.config
@@ -18,7 +18,7 @@ handlers:
         class: logging.handlers.RotatingFileHandler
         level: WARNING  # By default set to WARNING, but can be changed on runtime
         formatter: simple
-        filename: /var/log/runfolder/messages.log
+        filename: /var/log/arteria/runfolder.log
         maxBytes: 10485760  # 10MB
         backupCount: 20
         encoding: utf8

--- a/runfolder/tests/integration/rest_tests.py
+++ b/runfolder/tests/integration/rest_tests.py
@@ -17,7 +17,7 @@ class RestApiTestCase(BaseRestTest):
     # These tests are intended to be full integration tests, mocking nothing
     def setUp(self):
         self.messages_logged = TestFunctionDelta(
-            lambda: line_count('/var/log/runfolder/messages.log'), self, 0.1)
+            lambda: line_count('/var/log/arteria/runfolder.log'), self, 0.1)
 
     def test_can_change_log_level(self):
         self.put("./admin/log_level", {"log_level": "DEBUG"})


### PR DESCRIPTION
Logs are now located at /var/log/arteria/$product.log by default
Updated tests and config to reflect this