### PR TITLE
Moved the command line argument parsing to core

### DIFF
--- a/arteria/arteria/web/app.py
+++ b/arteria/arteria/web/app.py
@@ -5,7 +5,7 @@ import os
 from arteria.configuration import ConfigurationService
 from arteria.web.routes import RouteService
 from arteria.web.handlers import LogLevelHandler, ApiHelpHandler
-
+from optparse import OptionParser
 
 class AppService:
     """
@@ -14,22 +14,26 @@ class AppService:
     Automatically sets up logging, given a config_svc that serves a logging config
 
     Usage example:
-        # Set up using the factory method, which provides default location of
-        # config files:
-        app_svc = AppService.create("product_name", debug=True, port=8080)
+        def start():
+            # The following sets up a default AppService, reading
+            # default arguments from the command line, in particular
+            # --port and --product:
+            app_svc = AppService.create()
 
-        # This sets up the service reading config files from:
-        #  - /opt/product_name/etc/app.config
-        #  - /opt/product_name/etc/logger.config
+            # The service is now set up to read config files from:
+            #  - /opt/product_name/etc/app.config
+            #  - /opt/product_name/etc/logger.config
 
-        # Set up Tornado routes
-        args = dict(service1=Service1(), service2=Service2())
-        routes = [
-            (r"/api/1.0/endpoint1", Handler1, args),
-            (r"/api/1.0/endpoint2", Handler2, args)
-        ]
+            # Now set up Tornado routes
+            args = dict(service1=Service1(), service2=Service2())
+            routes = [
+                (r"/api/1.0/endpoint1", Handler1, args),
+                (r"/api/1.0/endpoint2", Handler2, args)
+            ]
 
-        app_svc.start(routes)
+            # Now start the service.
+            # The port will come from the command line argument --port
+            app_svc.start(routes)
     """
 
     def __init__(self, config_svc, debug, port, logger=None):
@@ -51,10 +55,16 @@ class AppService:
         self._tornado = None
 
     @staticmethod
-    def create(product_name, config_root, debug, port):
+    def create():
         """
-        Creates the default app service and related services with defaults
-        based on the product_name
+        Creates the default app service based on arguments sent from the command line
+        and related services with defaults based on the product_name
+
+        Command line usage: <program>
+                               --product <product name>
+                               --port <port>
+                               [--debug]
+                               [--configroot path]
 
         These config files should be accessible:
             - /opt/<product_name>/app.config
@@ -69,14 +79,22 @@ class AppService:
         :param debug: Set to true to run the application in debug mode. This affects
             how Tornado runs and how the route help is displayed
         """
-        if not config_root:
-            config_root = os.path.join("/opt", product_name, "etc")
+
+        parser = OptionParser()
+        parser.add_option("--product", dest="product", metavar="PRODUCT")
+        parser.add_option("--port", dest="port", metavar="PORT")
+        parser.add_option("--debug", dest="debug", action="store_true", default=False)
+        parser.add_option("--configroot", dest="configroot", metavar="CONFIGROOT")
+        (options, args) = parser.parse_args()
+
+        if not options.configroot:
+            config_root = os.path.join("/opt", options.product, "etc")
 
         logger_config_path = os.path.join(config_root, "logger.config")
         app_config_path = os.path.join(config_root, "app.config")
         config_svc = ConfigurationService(logger_config_path=logger_config_path,
                                           app_config_path=app_config_path)
-        app_svc = AppService(config_svc, debug, int(port))
+        app_svc = AppService(config_svc, options.debug, int(options.port))
         return app_svc
 
     def start(self, routes):
@@ -107,4 +125,7 @@ class AppService:
         ]
 
 class InvalidPortError(Exception):
+    pass
+
+class MissingArgumentError(Exception):
     pass

--- a/arteria/arteria/web/app.py
+++ b/arteria/arteria/web/app.py
@@ -127,5 +127,3 @@ class AppService:
 class InvalidPortError(Exception):
     pass
 
-class MissingArgumentError(Exception):
-    pass

--- a/runfolder/requirements/prod
+++ b/runfolder/requirements/prod
@@ -1,5 +1,4 @@
 arteria
 jsonpickle==0.9.2
 tornado==4.2.1
-click==4.1
 PyYAML==3.11

--- a/runfolder/runfolder/app.py
+++ b/runfolder/runfolder/app.py
@@ -1,14 +1,8 @@
-import click
 from arteria.web.app import AppService
 from runfolder.handlers import *
 
-@click.command()
-@click.option('--product', default=__package__)
-@click.option('--port')
-@click.option('--configroot')
-@click.option('--debug/--no-debug', default=False)
-def start(product, port, configroot, debug):
-    app_svc = AppService.create(product, configroot, debug, port)
+def start():
+    app_svc = AppService.create()
     runfolder_svc = RunfolderService(app_svc.config_svc)
 
     # Setup the routing. Help will be automatically available at /api, and will be based on
@@ -21,4 +15,3 @@ def start(product, port, configroot, debug):
         (r"/api/1.0/runfolders/test/markasready/path(/.*)", TestFakeSequencerReadyHandler, args)
     ]
     app_svc.start(routes)
-

--- a/runfolder/runfolder/app.py
+++ b/runfolder/runfolder/app.py
@@ -2,7 +2,7 @@ from arteria.web.app import AppService
 from runfolder.handlers import *
 
 def start():
-    app_svc = AppService.create()
+    app_svc = AppService.create(__package__)
     runfolder_svc = RunfolderService(app_svc.config_svc)
 
     # Setup the routing. Help will be automatically available at /api, and will be based on
@@ -15,3 +15,4 @@ def start():
         (r"/api/1.0/runfolders/test/markasready/path(/.*)", TestFakeSequencerReadyHandler, args)
     ]
     app_svc.start(routes)
+


### PR DESCRIPTION
The arguments are now read directly in core, removing the need for copying the argument setup (click) between services
Click is not required anymore. There were some issues with using it in this way so I moved over to using the built in optparse package.