### PR TITLE
Integration testing

### DIFF
--- a/bcl2fastq/Dockerfile
+++ b/bcl2fastq/Dockerfile
@@ -1,5 +1,5 @@
 # Pull base image.
-FROM centos:6
+FROM arteria/frozendata:latest
 
 ######################################
 # Ensure we have python 2.7 installed
@@ -30,19 +30,21 @@ RUN curl https://raw.githubusercontent.com/pypa/pip/master/contrib/get-pip.py | 
 # Ensure we have pip installed
 ######################################
 
-RUN rpm -ivh http://dl.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm
+#RUN rpm -ivh http://dl.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm
 
 RUN yum -y install python-pip
 
 ######################################
-# Install bcl2fastq 2.16
+# Install bcl2fastq 2.17
 ######################################
-RUN yum install -y http://support.illumina.com/content/dam/illumina-support/documents/downloads/software/bcl2fastq/bcl2fastq2-v2.16.0.10-Linux-x86_64.rpm
+RUN yum install -y http://support.illumina.com/content/dam/illumina-support/documents/downloads/software/bcl2fastq/bcl2fastq2-v2.17.1.14-Linux-x86_64.rpm
 
 
 ######################################
 # Setup for bcl2fastq-ws
 ######################################
+
+RUN mkdir -p /var/log/bcl2fastq_logs/
 
 # Expose default bcl2fastq-ws port
 EXPOSE 8888

--- a/bcl2fastq/README
+++ b/bcl2fastq/README
@@ -27,9 +27,11 @@ Install:
 
 Running integration tests in docker container (with a centos base):
 
-    sudo docker pull centos
-    sudo docker build -t bcl2fastq-ws .
-    sudo docker run -v $PWD:/bcl2fastq-ws -p 8888:8888 -t -i bcl2fastq-ws:latest /bin/bash
+    # NB: The container currently builds of an internal image.
+    #     We will work to find some publically available data,
+    #     to base of, but this is it for now.
+    docker build -t bcl2fastq-ws .
+    docker run -v $PWD:/bcl2fastq-ws -p 8888:8888 -t -i bcl2fastq-ws:latest /bin/bash
 
     # Once inside the docker container execute
     cd /bcl2fastq-ws/ && pip install -r requirements.txt && python2.7 setup.py install && python2.7 bcl2fastq/app.py --config config/bcl2fastq.integration_tests.config.yaml

--- a/bcl2fastq/bcl2fastq/lib/bcl2fastq_utils.py
+++ b/bcl2fastq/bcl2fastq/lib/bcl2fastq_utils.py
@@ -21,7 +21,7 @@ class Bcl2FastqConfig:
                  nbr_of_cores=None):
 
         self.runfolder_input = runfolder_input
-        self.samplesheet = runfolder_input + "/Samplesheet.csv"
+        self.samplesheet = runfolder_input + "/SampleSheet.csv"
         self.base_calls_input = runfolder_input + "/Data/Intensities/BaseCalls"
 
         if bcl2fastq_version:
@@ -53,12 +53,14 @@ class Bcl2FastqConfig:
             self.nbr_of_cores = multiprocessing.cpu_count()
 
     @staticmethod
-    def get_bcl2fastq_version_from_run_parameters(runfolder, config):
+    def get_bcl2fastq_version_from_run_parameters(runfolder, config=None):
         """
         Guess which bcl2fastq version to use based on the machine type
         specified in the runfolder meta data, and the corresponding
         mappings in the config file.
         :param runfolder: to get bcl2fastq version to use for
+        :param config: to use matching machine type to bcl2fastq versions (will be
+        loaded from default config if not set).
         :return the version of bcl2fastq to use.
         """
 
@@ -109,29 +111,29 @@ class Bcl2FastqConfig:
             if difference > 0:
                 return "n*"
             else:
-                ""
+                return ""
 
         def construct_double_index_basemask(idx):
             (index1, index2) = idx.split("-")
             index1_length = len(index1)
             index2_length = len(index2)
             return "y*,{0}{1}{2},{3}{4}{5},y*".format(
-                index1_length, "i", pad_with_ignore(index1_length, index_lengths[2]),
-                index2_length, "i", pad_with_ignore(index2_length, index_lengths[3]))
+                "i", index1_length, pad_with_ignore(index1_length, index_lengths[2]),
+                "i", index2_length, pad_with_ignore(index2_length, index_lengths[3]))
 
         def construct_single_index_basemask(idx, flowcell_has_double_idx):
             idx_length = len(idx)
             if flowcell_has_double_idx:
                 return "y*,{0}{1}{2},{3},y*".format(
-                    idx_length, "i", pad_with_ignore(idx_length, index_lengths[2]), "n*")
+                    "i", idx_length, pad_with_ignore(idx_length, index_lengths[2]), "n*")
             else:
-                return "y*,{0}{1}{2},y*".format(idx_length, "i", pad_with_ignore(idx_length, index_lengths[2]))
+                return "y*,{0}{1}{2},y*".format("i", idx_length, pad_with_ignore(idx_length, index_lengths[2]))
 
         samplesheet_df = read_csv(samplesheet_file)
         lanes_and_indexes = samplesheet_df.loc[:,["Lane","Index"]]
         first_index_and_lane = lanes_and_indexes.groupby(lanes_and_indexes.Lane).first()
         indexes = first_index_and_lane["Index"].to_dict()
-        contains_double_index = 2 in index_lengths
+        contains_double_index = len(index_lengths) > 1
 
         base_masks = {}
         for lane, read_index in indexes.iteritems():

--- a/bcl2fastq/config/bcl2fastq.config.yaml
+++ b/bcl2fastq/config/bcl2fastq.config.yaml
@@ -5,6 +5,9 @@
 # TODO Ensure all these mappings are correctly setup.
 bcl2fastq:
   versions:
+    2.17:
+      binary: bcl2fastq
+      class_creation_function:  _get_bcl2fastq2x_runner
     2.15.2:
       binary: /path/to/bcl2fastq
       class_creation_function:  _get_bcl2fastq2x_runner
@@ -14,17 +17,17 @@ bcl2fastq:
 
 machine_type:
   HiSeq X:
-    bcl2fastq_version: 2.15.2
+    bcl2fastq_version: 2.17
   HiSeq 2500:
-    bcl2fastq_version: 1.8.4
+    bcl2fastq_version: 2.17
   HiSeq 2000:
-    bcl2fastq_version: 1.8.4
+    bcl2fastq_version: 2.17
   NextSeq 500:
-    bcl2fastq_version: 1.8.4
+    bcl2fastq_version: 2.17
   HiSeq 4000:
-    bcl2fastq_version: 1.8.4
+    bcl2fastq_version: 2.17
   MiSeq:
-    bcl2fastq_version: 1.8.4
+    bcl2fastq_version: 2.17
 
 
 runfolder_path: /data/biotank3/runfolders

--- a/bcl2fastq/config/bcl2fastq.config.yaml
+++ b/bcl2fastq/config/bcl2fastq.config.yaml
@@ -5,7 +5,7 @@
 # TODO Ensure all these mappings are correctly setup.
 bcl2fastq:
   versions:
-    2.17:
+    2.17.1:
       binary: bcl2fastq
       class_creation_function:  _get_bcl2fastq2x_runner
     2.15.2:
@@ -17,17 +17,17 @@ bcl2fastq:
 
 machine_type:
   HiSeq X:
-    bcl2fastq_version: 2.17
+    bcl2fastq_version: 2.17.1
   HiSeq 2500:
-    bcl2fastq_version: 2.17
+    bcl2fastq_version: 2.17.1
   HiSeq 2000:
-    bcl2fastq_version: 2.17
+    bcl2fastq_version: 2.17.1
   NextSeq 500:
-    bcl2fastq_version: 2.17
+    bcl2fastq_version: 2.17.1
   HiSeq 4000:
-    bcl2fastq_version: 2.17
+    bcl2fastq_version: 2.17.1
   MiSeq:
-    bcl2fastq_version: 2.17
+    bcl2fastq_version: 2.17.1
 
 
 runfolder_path: /data/biotank3/runfolders

--- a/bcl2fastq/config/bcl2fastq.integration_tests.config.yaml
+++ b/bcl2fastq/config/bcl2fastq.integration_tests.config.yaml
@@ -5,6 +5,9 @@
 # TODO Ensure all these mappings are correctly setup.
 bcl2fastq:
   versions:
+    2.17:
+      binary: bcl2fastq
+      class_creation_function:  _get_bcl2fastq2x_runner
     2.16.0.10:
       binary: /usr/local/bin/bcl2fastq
       class_creation_function:  _get_bcl2fastq2x_runner
@@ -14,20 +17,20 @@ bcl2fastq:
 
 machine_type:
   HiSeq X:
-    bcl2fastq_version: 2.16.0.10
+    bcl2fastq_version: 2.17
   HiSeq 2500:
-    bcl2fastq_version: 1.8.4
+    bcl2fastq_version: 2.17
   HiSeq 2000:
-    bcl2fastq_version: 1.8.4
+    bcl2fastq_version: 2.17
   NextSeq 500:
-    bcl2fastq_version: 1.8.4
+    bcl2fastq_version: 2.17
   HiSeq 4000:
-    bcl2fastq_version: 1.8.4
+    bcl2fastq_version: 2.17
   MiSeq:
-    bcl2fastq_version: 1.8.4
+    bcl2fastq_version: 2.17
 
 
-runfolder_path: /bcl2fastq-ws/tmp_test_data
+runfolder_path: /data
 default_output_path: /tmp
 
 bcl2fastq_logs_path: /var/log/bcl2fastq_logs

--- a/bcl2fastq/config/bcl2fastq.integration_tests.config.yaml
+++ b/bcl2fastq/config/bcl2fastq.integration_tests.config.yaml
@@ -5,7 +5,7 @@
 # TODO Ensure all these mappings are correctly setup.
 bcl2fastq:
   versions:
-    2.17:
+    2.17.1:
       binary: bcl2fastq
       class_creation_function:  _get_bcl2fastq2x_runner
     2.16.0.10:
@@ -17,17 +17,17 @@ bcl2fastq:
 
 machine_type:
   HiSeq X:
-    bcl2fastq_version: 2.17
+    bcl2fastq_version: 2.17.1
   HiSeq 2500:
-    bcl2fastq_version: 2.17
+    bcl2fastq_version: 2.17.1
   HiSeq 2000:
-    bcl2fastq_version: 2.17
+    bcl2fastq_version: 2.17.1
   NextSeq 500:
-    bcl2fastq_version: 2.17
+    bcl2fastq_version: 2.17.1
   HiSeq 4000:
-    bcl2fastq_version: 2.17
+    bcl2fastq_version: 2.17.1
   MiSeq:
-    bcl2fastq_version: 2.17
+    bcl2fastq_version: 2.17.1
 
 
 runfolder_path: /data

--- a/bcl2fastq/tests/tests_bcl2fastq.py
+++ b/bcl2fastq/tests/tests_bcl2fastq.py
@@ -19,17 +19,15 @@ class TestBcl2FastqConfig(unittest.TestCase):
         self.assertEqual(index_and_length, {2: 7})
 
     def test_get_bases_mask_per_lane_from_samplesheet(self):
-        #TODO Fix test to match that we might now have a read that uses the full
-        # lenght of the read.
         mock_read_index_lengths = {2: 9, 3: 9}
-        expected_bases_mask = {1: "y*,8in*,8in*,y*",
-                               2: "y*,6in*,n*,y*",
-                               3: "y*,6in*,n*,y*",
-                               4: "y*,7in*,n*,y*",
-                               5: "y*,7in*,n*,y*",
-                               6: "y*,7in*,n*,y*",
-                               7: "y*,7in*,n*,y*",
-                               8: "y*,7in*,n*,y*",
+        expected_bases_mask = {1: "y*,i8n*,i8n*,y*",
+                               2: "y*,i6n*,n*,y*",
+                               3: "y*,i6n*,n*,y*",
+                               4: "y*,i7n*,n*,y*",
+                               5: "y*,i7n*,n*,y*",
+                               6: "y*,i7n*,n*,y*",
+                               7: "y*,i7n*,n*,y*",
+                               8: "y*,i7n*,n*,y*",
                                }
         actual_bases_mask = Bcl2FastqConfig.\
             get_bases_mask_per_lane_from_samplesheet(TestBcl2FastqConfig.samplesheet_file, mock_read_index_lengths)
@@ -83,7 +81,7 @@ class TestBCL2Fastq2xRunner(unittest.TestCase):
             output = "test/output",
             barcode_mismatches = "2",
             tiles="s1,s2,s3",
-            use_base_mask="--use-bases-mask y*,6i,6i,y* --use-bases-mask 1:y*,5i,5i,y*",
+            use_base_mask="--use-bases-mask y*,i6,i6,y* --use-bases-mask 1:y*,i5,i5,y*",
             additional_args="--my-best-arg 1 --my-best-arg 2")
 
         runner = BCL2Fastq2xRunner(config, "/bcl/binary/path")
@@ -91,7 +89,7 @@ class TestBCL2Fastq2xRunner(unittest.TestCase):
         expected_command = "/bcl/binary/path --input-dir test/runfolder/Data/Intensities/BaseCalls " \
                            "--output-dir test/output --barcode-mismatches 2 " \
                            "--tiles s1,s2,s3 " \
-                           "--use-bases-mask y*,6i,6i,y* --use-bases-mask 1:y*,5i,5i,y* " \
+                           "--use-bases-mask y*,i6,i6,y* --use-bases-mask 1:y*,i5,i5,y* " \
                            "--my-best-arg 1 --my-best-arg 2"
         self.assertEqual(command, expected_command)
 
@@ -134,7 +132,7 @@ class TestBCL2Fastq1xRunner(unittest.TestCase):
         command = runner_1.construct_command()
         expected_command = "configureBclToFastq.pl " \
                            "--input-dir test/runfolder/Data/Intensities/BaseCalls " \
-                           "--sample-sheet test/runfolder/Samplesheet.csv " \
+                           "--sample-sheet test/runfolder/SampleSheet.csv " \
                            "--output-dir test/output " \
                            "--fastq-cluster-count 0 " \
                            "--force " \


### PR DESCRIPTION
I've now carried out the first successful run of bcl2fastq via the bcl2fastq arteria service. This PR contains the changes to the docker image required to make this work, and problems that I identified which had not been picked up by previous testing.

A remaining issue is the bcl2fastq seems to require the "new" style of samplesheet. If a "old" style samplesheet is provided, it will run, but put all the data in unidentified instead. We should probably introduce a check for this - however we need to ensure compatibility with downstream sisyphus script (some of which I suspect might require the old style of samplesheet to be available).