### PR TITLE
Abstract Samplesheet to it's own class

### DIFF
--- a/bcl2fastq/bcl2fastq/lib/bcl2fastq_utils.py
+++ b/bcl2fastq/bcl2fastq/lib/bcl2fastq_utils.py
@@ -1,8 +1,11 @@
 import subprocess
-from bcl2fastq.lib.config import Config
 import os.path
-from illuminate.metadata import InteropMetadata
 from itertools import groupby
+
+from illuminate.metadata import InteropMetadata
+
+from bcl2fastq.lib.config import Config
+from bcl2fastq.lib.illumina import Samplesheet
 
 class Bcl2FastqConfig:
     """
@@ -263,8 +266,9 @@ class BCL2Fastq2xRunner(BCL2FastqRunner):
             commandline_collection.append(self.config.use_base_mask)
         else:
             length_of_indexes = Bcl2FastqConfig.get_length_of_indexes(self.config.runfolder_input)
+            samplesheet = Samplesheet(self.config.samplesheet_file)
             lanes_and_base_mask = Bcl2FastqConfig.\
-                get_bases_mask_per_lane_from_samplesheet(self.config.samplesheet_file, length_of_indexes)
+                get_bases_mask_per_lane_from_samplesheet(samplesheet, length_of_indexes)
             for lane, base_mask in lanes_and_base_mask.iteritems():
                 commandline_collection.append("--use-bases-mask {0}:{1}".format(lane, base_mask))
 
@@ -307,8 +311,9 @@ class BCL2Fastq1xRunner(BCL2FastqRunner):
             commandline_collection.append("--use_bases_mask " + self.config.use_base_mask)
         else:
             length_of_indexes = Bcl2FastqConfig.get_length_of_indexes(self.config.runfolder_input)
+            samplesheet = Samplesheet(self.config.samplesheet_file)
             lanes_and_base_mask = \
-                Bcl2FastqConfig.get_bases_mask_per_lane_from_samplesheet(self.config.samplesheet_file, length_of_indexes)
+                Bcl2FastqConfig.get_bases_mask_per_lane_from_samplesheet(samplesheet, length_of_indexes)
             base_masks_as_set = set(lanes_and_base_mask.values())
 
             assert len(base_masks_as_set) is 1, "For bcl2fastq 1.8.4 there is no support for " \

--- a/bcl2fastq/bcl2fastq/lib/bcl2fastq_utils.py
+++ b/bcl2fastq/bcl2fastq/lib/bcl2fastq_utils.py
@@ -130,10 +130,10 @@ class Bcl2FastqConfig:
             else:
                 return "y*,{0}{1}{2},y*".format("i", idx_length, pad_with_ignore(idx_length, index_lengths[2]))
 
-        def key_func(x):
+        def by_lane(x):
             return x.lane
-        sample_rows_sorted_by_lane = sorted(samplesheet.samples, key=key_func)
-        lanes_and_indexes = groupby(sample_rows_sorted_by_lane, key_func)
+        sample_rows_sorted_by_lane = sorted(samplesheet.samples, key=by_lane)
+        lanes_and_indexes = groupby(sample_rows_sorted_by_lane, by_lane)
 
         first_sample_in_each_lane = {k: next(v) for k, v in lanes_and_indexes}
 

--- a/bcl2fastq/bcl2fastq/lib/bcl2fastq_utils.py
+++ b/bcl2fastq/bcl2fastq/lib/bcl2fastq_utils.py
@@ -3,7 +3,6 @@ from bcl2fastq.lib.config import Config
 import os.path
 from illuminate.metadata import InteropMetadata
 from itertools import groupby
-from lib.illumina import Samplesheet
 
 class Bcl2FastqConfig:
     """

--- a/bcl2fastq/bcl2fastq/lib/illumina.py
+++ b/bcl2fastq/bcl2fastq/lib/illumina.py
@@ -42,33 +42,13 @@ class Samplesheet:
             assert len(lines_with_data) == 1, "The wasn't strictly one line in samplesheet with line '[Data]'"
             return lines_with_data[0][0]
 
-        # REVIEW If anyone has a better idea than this I'd be happy to head it.
-        # The setup for this now is not pretty!
-        # The Reason that this is done in this way is that not all fields
-        # will exist depending on the type of run. In particular the "Lane" column
-        # is not available in MiSeq samplesheets. /JD 20150813
         def row_to_sample_row(index_and_row):
             row = index_and_row[1]
-            
-            def single_index_row_to_sample_row(this_row, lane=None):
-                  return SampleRow(lane or this_row["Lane"], this_row["Sample_ID"], this_row["Sample_Name"],
-                                     this_row["Sample_Plate"], this_row["Sample_Well"],
-                                     this_row["index"], "", this_row["Sample_Project"], this_row["Description"])
-
-            def double_index_row_to_sample_row(this_row, lane=None):
-                    return SampleRow(lane or this_row["Lane"], this_row["Sample_ID"], this_row["Sample_Name"],
-                                     this_row["Sample_Plate"], this_row["Sample_Well"],
-                                     this_row["index"], this_row["index2"], this_row["Sample_Project"], this_row["Description"])
-            if "Lane" in row:
-                if "index2" in row:
-                    return double_index_row_to_sample_row(row)
-                else:
-                    return single_index_row_to_sample_row(row)
-            else:
-                if "index2" in row:
-                    return double_index_row_to_sample_row(row, 1)
-                else:
-                    return single_index_row_to_sample_row(row, 1)
+            default_lane = 1 # MiSeq samplesheets do not contain any lane information - so we will default this to 1.
+            default_index2 = ""
+            return SampleRow(row.get("Lane", default_lane), row["Sample_ID"], row["Sample_Name"],
+                             row["Sample_Plate"], row["Sample_Well"],
+                             row["index"], row.get("index2", default_index2), row["Sample_Project"], row["Description"])
 
         lines_to_skip = find_data_line() + 1
         # Ensure that pointer is at beginning of file again.

--- a/bcl2fastq/bcl2fastq/lib/illumina.py
+++ b/bcl2fastq/bcl2fastq/lib/illumina.py
@@ -1,22 +1,46 @@
 
 from pandas import read_csv
 
-# TODO Implement picking up additional information from
-# samplesheet. Right only picking up the data field is
-# supported.
-
 class SampleRow:
-    def __init__(self, lane, sample_id, sample_name, sample_plate,
-                 sample_well, index1, index2, sample_project, description):
+    """
+    Provides a representation of the information presented in a Illumina Samplesheet.
+    Different samplesheet types (e.g. HiSeq, MiSeq, etc) will provide slightly different
+    information for each sample. This class aims at providing a interface to this that will
+    hopefully stay relatively stable across time.
+
+    For an example of how the samplesheet looks see: ./tests/sampledata/new_samplesheet_example.csv
+
+    TODO Implement picking up additional information from
+    samplesheet. Right only picking up the data field is
+    supported.
+    """
+    def __init__(self, sample_id, sample_name, index1, sample_project, lane=1, sample_plate=None,
+                 sample_well=None, index2=None, description=None):
+        """
+        Constructs the SampleRow, which shadows the information on each sequencing unit (lane, sample, tag, etc)
+        in the samplesheet. NB: If a field is set to None, it means that column didn't exist in the samplesheet.
+        If it is a empty string it means that it was set to a empty value.
+        :param sample_id: unique id of sample
+        :param sample_name: the name of the sample
+        :param index1: index to demultiplex by
+        :param sample_project: project sample belongs to
+        :param lane: sequenced on - will default to 1 if not set (e.g. the MiSeq samplesheet does
+        not contain lane information
+        :param sample_plate: plate the sample was taken from
+        :param sample_well: well on plate
+        :param index2: second index in the case of dual indexing
+        :param description: a free text field containing additional info about the sample
+        :return:
+        """
         self.lane = int(lane)
         self.sample_id = str(sample_id)
         self.sample_name = str(sample_name)
-        self.sample_plate = str(sample_plate)
-        self.sample_well = str(sample_well)
-        self.index1 = str(index1)
-        self.index2 = str(index2)
+        self.sample_plate = sample_plate
+        self.sample_well = sample_well
+        self.index1 = index1
+        self.index2 = index2
         self.sample_project = str(sample_project)
-        self.description = str(description)
+        self.description = description
 
     def __str__(self):
         return str(self.__dict__)
@@ -28,13 +52,26 @@ class SampleRow:
             False
 
 class Samplesheet:
+    """
+    Represent information contanied in a Illumina samplesheet
+    """
+
     def __init__(self, samplesheet_file):
+        """
+        Create a Samplesheet instance.
+        :param samplesheet_file: a path to the samplesheet file to read
+        """
         self.samplesheet_file = samplesheet_file
         with open(samplesheet_file, mode="r") as s:
             self.samples = self._read_samples(s)
 
     @staticmethod
     def _read_samples(samplesheet_file_handle):
+        """
+        Read info about the sequencing units in the samplesheet.
+        :param samplesheet_file_handle: file handle for the corresponding samplesheet
+        :return: a list of the sequencing units in the samplesheet in the form of `SampleRow` instances.
+        """
 
         def find_data_line():
             enumurated_lines = enumerate(samplesheet_file_handle)
@@ -44,11 +81,10 @@ class Samplesheet:
 
         def row_to_sample_row(index_and_row):
             row = index_and_row[1]
-            default_lane = 1 # MiSeq samplesheets do not contain any lane information - so we will default this to 1.
-            default_index2 = ""
-            return SampleRow(row.get("Lane", default_lane), row["Sample_ID"], row["Sample_Name"],
-                             row["Sample_Plate"], row["Sample_Well"],
-                             row["index"], row.get("index2", default_index2), row["Sample_Project"], row["Description"])
+            return SampleRow(lane=row.get("Lane"), sample_id=row.get("Sample_ID"), sample_name=row.get("Sample_Name"),
+                             sample_plate=row.get("Sample_Plate"), sample_well=row.get("Sample_Well"),
+                             index1=row.get("index"), index2=row.get("index2"),
+                             sample_project=row.get("Sample_Project"), description=row.get("Description"))
 
         lines_to_skip = find_data_line() + 1
         # Ensure that pointer is at beginning of file again.

--- a/bcl2fastq/bcl2fastq/lib/illumina.py
+++ b/bcl2fastq/bcl2fastq/lib/illumina.py
@@ -1,0 +1,79 @@
+
+from pandas import read_csv
+
+# TODO Implement picking up additional information from
+# samplesheet. Right only picking up the data field is
+# supported.
+
+class SampleRow:
+    def __init__(self, lane, sample_id, sample_name, sample_plate,
+                 sample_well, index1, index2, sample_project, description):
+        self.lane = int(lane)
+        self.sample_id = str(sample_id)
+        self.sample_name = str(sample_name)
+        self.sample_plate = str(sample_plate)
+        self.sample_well = str(sample_well)
+        self.index1 = str(index1)
+        self.index2 = str(index2)
+        self.sample_project = str(sample_project)
+        self.description = str(description)
+
+    def __str__(self):
+        return str(self.__dict__)
+
+    def __eq__(self, other):
+        if type(other) == type(self):
+            return self.__dict__ == other.__dict__
+        else:
+            False
+
+class Samplesheet:
+    def __init__(self, samplesheet_file):
+        self.samplesheet_file = samplesheet_file
+        with open(samplesheet_file, mode="r") as s:
+            self.samples = self._read_samples(s)
+
+    @staticmethod
+    def _read_samples(samplesheet_file_handle):
+
+        def find_data_line():
+            enumurated_lines = enumerate(samplesheet_file_handle)
+            lines_with_data = filter(lambda x: "[Data]" in x[1], enumurated_lines)
+            assert len(lines_with_data) == 1, "The wasn't strictly one line in samplesheet with line '[Data]'"
+            return lines_with_data[0][0]
+
+        # REVIEW If anyone has a better idea than this I'd be happy to head it.
+        # The setup for this now is not pretty!
+        # The Reason that this is done in this way is that not all fields
+        # will exist depending on the type of run. In particular the "Lane" column
+        # is not available in MiSeq samplesheets. /JD 20150813
+        def row_to_sample_row(index_and_row):
+            row = index_and_row[1]
+            
+            def single_index_row_to_sample_row(this_row, lane=None):
+                  return SampleRow(lane or this_row["Lane"], this_row["Sample_ID"], this_row["Sample_Name"],
+                                     this_row["Sample_Plate"], this_row["Sample_Well"],
+                                     this_row["index"], "", this_row["Sample_Project"], this_row["Description"])
+
+            def double_index_row_to_sample_row(this_row, lane=None):
+                    return SampleRow(lane or this_row["Lane"], this_row["Sample_ID"], this_row["Sample_Name"],
+                                     this_row["Sample_Plate"], this_row["Sample_Well"],
+                                     this_row["index"], this_row["index2"], this_row["Sample_Project"], this_row["Description"])
+            if "Lane" in row:
+                if "index2" in row:
+                    return double_index_row_to_sample_row(row)
+                else:
+                    return single_index_row_to_sample_row(row)
+            else:
+                if "index2" in row:
+                    return double_index_row_to_sample_row(row, 1)
+                else:
+                    return single_index_row_to_sample_row(row, 1)
+
+        lines_to_skip = find_data_line() + 1
+        # Ensure that pointer is at beginning of file again.
+        samplesheet_file_handle.seek(0)
+        samplesheet_df = read_csv(samplesheet_file_handle, skiprows=lines_to_skip)
+        samplesheet_df = samplesheet_df.fillna("")
+        samples = map(row_to_sample_row, samplesheet_df.iterrows())
+        return list(samples)

--- a/bcl2fastq/tests/sampledata/new_samplesheet_example.csv
+++ b/bcl2fastq/tests/sampledata/new_samplesheet_example.csv
@@ -1,0 +1,29 @@
+[Header],,,,,,,,,,,
+IEMFileVersion,4,,,,,,,,,,
+Experiment Name,Hiseq-2500-dual-index,,,,,,,,,,
+Date,8/13/2015,,,,,,,,,,
+Workflow,Resequencing,,,,,,,,,,
+Application,Human Genome Resequencing,,,,,,,,,,
+Assay,TruSeq HT,,,,,,,,,,
+Description,,,,,,,,,,,
+Chemistry,Amplicon,,,,,,,,,,
+,,,,,,,,,,,
+[Reads],,,,,,,,,,,
+151,,,,,,,,,,,
+151,,,,,,,,,,,
+,,,,,,,,,,,
+[Settings],,,,,,,,,,,
+FlagPCRDuplicates,1,,,,,,,,,,
+Adapter,AGATCGGAAGAGCACACGTCTGAACTCCAGTCA,,,,,,,,,,
+AdapterRead2,AGATCGGAAGAGCGTCGTGTAGGGAAAGAGTGT,,,,,,,,,,
+,,,,,,,,,,,
+[Data],,,,,,,,,,,
+Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,I5_Index_ID,index2,Sample_Project,Description,GenomeFolder
+1,1,1,,,D701,ATTACTCG,D501,TATAGCCT,Test,Hiseq2500-dual-index,Homo_sapiens\UCSC\hg19\Sequence\WholeGenomeFasta
+2,2,2,,,D702,TCCGGA,D503,,Test,Hiseq2500-dual-index,Homo_sapiens\UCSC\hg19\Sequence\WholeGenomeFasta
+3,3,3,,,D703,CGCTCA,D503,,Test,Hiseq2500-dual-index,Homo_sapiens\UCSC\hg19\Sequence\WholeGenomeFasta
+4,4,4,,,D704,GAGATTC,D504,,Test,Hiseq2500-dual-index,Homo_sapiens\UCSC\hg19\Sequence\WholeGenomeFasta
+5,5,5,,,D705,ATTCAGA,D505,,Test,Hiseq2500-dual-index,Homo_sapiens\UCSC\hg19\Sequence\WholeGenomeFasta
+6,6,6,,,D706,GAATTCG,D506,,Test,Hiseq2500-dual-index,Homo_sapiens\UCSC\hg19\Sequence\WholeGenomeFasta
+7,7,7,,,D707,CTGAAGC,D507,,Test,Hiseq2500-dual-index,Homo_sapiens\UCSC\hg19\Sequence\WholeGenomeFasta
+8,8,8,,,D708,TAATGCG,D508,,Test,Hiseq2500-dual-index,Homo_sapiens\UCSC\hg19\Sequence\WholeGenomeFasta

--- a/bcl2fastq/tests/test_bcl2fastq_handlers.py
+++ b/bcl2fastq/tests/test_bcl2fastq_handlers.py
@@ -36,12 +36,21 @@ class TestBcl2FastqHandlers(AsyncHTTPTestCase):
         self.assertEqual(response.code, 500)
 
     def test_start(self):
+        from bcl2fastq.lib.bcl2fastq_utils import BCL2FastqRunner
+
+        class FakeRunner(BCL2FastqRunner):
+            def __init__(self):
+                pass
+
+            def construct_command(self):
+                return "fake_bcl_command"
+
         # Use mock to ensure that this will run without
         # creating the runfolder.
         with mock.patch.object(Config, 'load_config', return_value=TestUtils.DUMMY_CONFIG), \
              mock.patch.object(os.path, 'isdir', return_value=True), \
              mock.patch.object(Bcl2FastqConfig, 'get_bcl2fastq_version_from_run_parameters', return_value="2.15.2"), \
-             mock.patch.object(Bcl2FastqConfig, 'get_bases_mask_per_lane_from_samplesheet', return_value=self.MOCK_BCL2FASTQ_DICT):
+             mock.patch.object(BCL2FastqRunnerFactory, "create_bcl2fastq_runner", return_value=FakeRunner()):
 
             body = {"runfolder_input": "/path/to/runfolder"}
             response = self.fetch(self.API_BASE + "/start/150415_D00457_0091_AC6281ANXX", method="POST", body=json_encode(body))

--- a/bcl2fastq/tests/test_illumina.py
+++ b/bcl2fastq/tests/test_illumina.py
@@ -18,13 +18,13 @@ Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,Sample_Pro
 """
 
     expected_samples = [
-        SampleRow(lane="1", sample_id="1", sample_name="1", sample_plate="",
-                  sample_well="", index1="CAGATC", index2="",
-                  sample_project="Dummy-Project",
+        SampleRow(lane="1", sample_id="1", sample_name="1",
+                  sample_well="", sample_plate="",
+                  index1="CAGATC", sample_project="Dummy-Project",
                   description="FRAGMENT_SIZE:387;FRAGMENT_LOWER:180;FRAGMENT_UPPER:580;LIBRARY_NAME:SX444_1"),
-        SampleRow(lane="1", sample_id="2", sample_name="2", sample_plate="",
-                  sample_well="", index1="ACTTGA", index2="",
-                  sample_project="Dummy-Project",
+        SampleRow(lane="1", sample_id="2", sample_name="2",
+                  sample_well="", sample_plate="",
+                  index1="ACTTGA", sample_project="Dummy-Project",
                   description="FRAGMENT_SIZE:387;FRAGMENT_LOWER:180;FRAGMENT_UPPER:580;LIBRARY_NAME:SX444_2")
     ]
 

--- a/bcl2fastq/tests/test_illumina.py
+++ b/bcl2fastq/tests/test_illumina.py
@@ -2,7 +2,7 @@ import unittest
 import os
 from cStringIO import StringIO
 
-from lib.illumina import *
+from bcl2fastq.lib.illumina import *
 
 
 

--- a/bcl2fastq/tests/test_illumina.py
+++ b/bcl2fastq/tests/test_illumina.py
@@ -1,0 +1,42 @@
+import unittest
+import os
+from cStringIO import StringIO
+
+from lib.illumina import *
+
+
+
+class TestSamplesheet(unittest.TestCase):
+    test_dir = os.path.dirname(os.path.realpath(__file__))
+    samplesheet_file = test_dir + "/sampledata/new_samplesheet_example.csv"
+    tiny_dummy_samplesheet_string = """
+,,,,,,,,
+[Data],,,,,,,,
+Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,Sample_Project,Description
+1,1,1,,,,CAGATC,Dummy-Project,FRAGMENT_SIZE:387;FRAGMENT_LOWER:180;FRAGMENT_UPPER:580;LIBRARY_NAME:SX444_1
+1,2,2,,,,ACTTGA,Dummy-Project,FRAGMENT_SIZE:387;FRAGMENT_LOWER:180;FRAGMENT_UPPER:580;LIBRARY_NAME:SX444_2
+"""
+
+    expected_samples = [
+        SampleRow(lane="1", sample_id="1", sample_name="1", sample_plate="",
+                  sample_well="", index1="CAGATC", index2="",
+                  sample_project="Dummy-Project",
+                  description="FRAGMENT_SIZE:387;FRAGMENT_LOWER:180;FRAGMENT_UPPER:580;LIBRARY_NAME:SX444_1"),
+        SampleRow(lane="1", sample_id="2", sample_name="2", sample_plate="",
+                  sample_well="", index1="ACTTGA", index2="",
+                  sample_project="Dummy-Project",
+                  description="FRAGMENT_SIZE:387;FRAGMENT_LOWER:180;FRAGMENT_UPPER:580;LIBRARY_NAME:SX444_2")
+    ]
+
+    def test_samplesheet(self):
+        # TODO This can probably improved by using mocks in some smart way
+        # TODO but right it doesn't feel like it's worth it. /JD 20150813
+        result = Samplesheet(TestSamplesheet.samplesheet_file)
+        self.assertEqual(len(result.samples), 8)
+
+    def test__read_samples(self):
+        result = Samplesheet._read_samples(StringIO(TestSamplesheet.tiny_dummy_samplesheet_string))
+        self.assertItemsEqual(result, TestSamplesheet.expected_samples)
+
+
+

--- a/bcl2fastq/tests/tests_bcl2fastq.py
+++ b/bcl2fastq/tests/tests_bcl2fastq.py
@@ -1,12 +1,13 @@
 import unittest
 
 from bcl2fastq.lib.bcl2fastq_utils import *
+from lib.illumina import Samplesheet
 from test_utils import TestUtils
 
 class TestBcl2FastqConfig(unittest.TestCase):
 
     test_dir = os.path.dirname(os.path.realpath(__file__))
-    samplesheet_file = test_dir + "/sampledata/samplesheet_example.csv"
+    samplesheet_file = test_dir + "/sampledata/new_samplesheet_example.csv"
 
     def test_get_bcl2fastq_version_from_run_parameters(self):
         runfolder = TestBcl2FastqConfig.test_dir + "/sampledata/HiSeq-samples/2014-02_13_average_run"
@@ -29,17 +30,19 @@ class TestBcl2FastqConfig(unittest.TestCase):
                                7: "y*,i7n*,n*,y*",
                                8: "y*,i7n*,n*,y*",
                                }
+        samplesheet = Samplesheet(TestBcl2FastqConfig.samplesheet_file)
         actual_bases_mask = Bcl2FastqConfig.\
-            get_bases_mask_per_lane_from_samplesheet(TestBcl2FastqConfig.samplesheet_file, mock_read_index_lengths)
+            get_bases_mask_per_lane_from_samplesheet(samplesheet, mock_read_index_lengths)
         self.assertEqual(expected_bases_mask, actual_bases_mask)
 
     def test_get_bases_mask_per_lane_from_samplesheet_invalid_length_combo(self):
         # These are to short compared to the length indicated in the samplesheet
         mock_read_index_lengths = {2: 4, 3: 4}
+        samplesheet = Samplesheet(TestBcl2FastqConfig.samplesheet_file)
 
         with self.assertRaises(AssertionError):
             Bcl2FastqConfig.\
-                get_bases_mask_per_lane_from_samplesheet(TestBcl2FastqConfig.samplesheet_file, mock_read_index_lengths)
+                get_bases_mask_per_lane_from_samplesheet(samplesheet, mock_read_index_lengths)
 
 
 class TestBCL2FastqRunnerFactory(unittest.TestCase):

--- a/bcl2fastq/tests/tests_bcl2fastq.py
+++ b/bcl2fastq/tests/tests_bcl2fastq.py
@@ -1,7 +1,7 @@
 import unittest
 
 from bcl2fastq.lib.bcl2fastq_utils import *
-from lib.illumina import Samplesheet
+from bcl2fastq.lib.illumina import Samplesheet
 from test_utils import TestUtils
 
 class TestBcl2FastqConfig(unittest.TestCase):


### PR DESCRIPTION
I've abstracted out the samplesheet into it's own class to hide away the actual messy samplesheet representation from the rest of the code. I've run manual manual integration tests with a MiSeq runfolder and all appeared to be working at that time.