### PR TITLE
Ensuring that routes are sorted before grouped

### DIFF
--- a/arteria/arteria/web/routes.py
+++ b/arteria/arteria/web/routes.py
@@ -92,7 +92,9 @@ class RouteService:
             ...
         """
         route_infos = list(self._get_route_infos(tornado_routes, base_url))
-        grouped = itertools.groupby(route_infos, lambda entry: entry.route)
+        by_route = lambda entry: entry.route
+        route_infos_sorted = sorted(route_infos, key=by_route)
+        grouped = itertools.groupby(route_infos_sorted, key=by_route)
         routes = []
         for key, groups in grouped:
             route_info = {"route": key}


### PR DESCRIPTION
The function itertools.groupby, unlike group by in SQL, requires sorting.